### PR TITLE
Encoding for Zero-width space is not collect

### DIFF
--- a/src/Crossjoin/PreMailer/PreMailerAbstract.php
+++ b/src/Crossjoin/PreMailer/PreMailerAbstract.php
@@ -496,7 +496,7 @@ abstract class PreMailerAbstract
                     // and mark links as non-breakable
                     $breakLongLines = true;
                     if (strpos($part, "\t")) {
-                        $part = str_replace("\t", mb_convert_encoding("\xE2\x80\x8C", $charset, "UTF-8"), $part);
+                        $part = str_replace("\t", mb_convert_encoding("\xE2\x80\x8B", $charset, "UTF-8"), $part);
                         $breakLongLines = false;
                     }
 


### PR DESCRIPTION
the comment says "Replace character before/after links with a zero width space," but the encoding is specifying zero-width non-joiner, not zero-width space.