### PR TITLE
Respect <br> tags

### DIFF
--- a/src/Crossjoin/PreMailer/PreMailerAbstract.php
+++ b/src/Crossjoin/PreMailer/PreMailerAbstract.php
@@ -609,6 +609,8 @@ abstract class PreMailerAbstract
                 $suffix = "*";
             } elseif ($node->nodeName === 'hr') {
                 $text .= str_repeat('-', $lineCharWidth) . "\n\n";
+            } elseif ($node->nodeName === 'br') {
+                $text .= "\n";
             }
 
             if ($node->hasChildNodes()) {


### PR DESCRIPTION
Leave `<br>` tags as `\n` in text mail to make text mail look similar to html mail.